### PR TITLE
Clean up demonstration usage of `SimpleNetworkWrapper`

### DIFF
--- a/chapter-07/forge-extension/simple-network-wrapper.md
+++ b/chapter-07/forge-extension/simple-network-wrapper.md
@@ -62,15 +62,15 @@ public class MessageFoo implements IMessage {
 
     @Override
     public void toBytes(ByteBuf buf) {
-        buf.writeLong(this.bar.getLeastSignificantBits());
         buf.writeLong(this.bar.getMostSignificantBits());
+        buf.writeLong(this.bar.getLeastSignificantBits());
     }
 
     @Override
     public void fromBytes(ByteBuf buf) {
-        final long least = buf.readLong();
         final long most = buf.readLong();
-        this.bar = new UUID(least, most);
+        final long least = buf.readLong();
+        this.bar = new UUID(most, least);
     }
 
     // 以及对应的 Handler，通常是静态内部类

--- a/chapter-07/forge-extension/simple-network-wrapper.md
+++ b/chapter-07/forge-extension/simple-network-wrapper.md
@@ -1,7 +1,7 @@
 # 残酷的事实和救世者：`SimpleNetworkWrapper`
 
-说完这么多，但是还是没回答一开始的问题：怎么处理网络 IO？  
-很抱歉你要自己想办法。  
+~~说完这么多，但是还是没回答一开始的问题：怎么处理网络 IO？~~  
+~~很抱歉你要自己想办法。~~  
 
 开玩笑的。MinecraftForge 有几个已经封装好的解决方案，直接拿去用就可以了。
 
@@ -11,16 +11,15 @@
 public enum MySimpleNetworkHandler {
     INSTANCE;
 
+    // 首先我们拿到一个 SimpleNetworkWrapper 的实例，然后对它进行封装
     private final SimpleNetworkWrapper channel = NetworkRegistry.INSTANCE.newSimpleChannel("example_mod");
 
-    //从这里开始就是一堆封装...
-
-    //向某个维度发包
+    // 向某个维度发包（服务器到客户端）
     public void sendMessageToDim(IMessage msg, int dim) {
         channel.sendToDimension(msg, dim);
     }
 
-    //向某个维度的某个点发包
+    // 向某个维度的某个点发包（服务器到客户端）
     public void sendMessageAroundPos(IMessage msg, int dim, BlockPos pos) {
         // TargetPoint的构造器为：
         // 维度id x坐标 y坐标 z坐标 覆盖范围
@@ -28,17 +27,17 @@ public enum MySimpleNetworkHandler {
         channel.sendToAllAround(msg, new NetworkRegistry.TargetPoint(dim, pos.getX(), pos.getY(), pos.getZ(), 2.0D);
     }
 
-    //向某个玩家发包
+    // 向某个玩家发包（服务器到客户端）
     public void sendMessageToPlayer(IMessage msg, EntityPlayerMP player) {
         channel.sendToPlayer(msg, player);
     }
 
-    //向所有人发包
+    // 向所有人发包（服务器到客户端）
     public void sendMessageToAll(IMessage msg) {
         channel.sendToAll(msg);
     }
 
-    //向服务器发包
+    // 向服务器发包（客户端到服务器）
     public void sendMessageToServer(IMessage msg) {
         channel.sendToServer(msg);
     }
@@ -48,24 +47,28 @@ public enum MySimpleNetworkHandler {
 然后是数据包：
 
 ```java
+import java.util.UUID;
+
 public class MessageFoo implements IMessage {
-    //解包用的构造器
+
+    UUID bar;
+
+    // 解包用的构造器
     public MessageFoo() {}
 
-    //别问我为毛是这个
-    java.util.UUID bar;
-
-    //封包用的构造器
+    // 封包用的构造器
     public MessageFoo(UUID uuid) {
         this.bar = uuid;
     }
 
+    // 封包
     @Override
     public void toBytes(ByteBuf buf) {
         buf.writeLong(this.bar.getMostSignificantBits());
         buf.writeLong(this.bar.getLeastSignificantBits());
     }
 
+    // 解包
     @Override
     public void fromBytes(ByteBuf buf) {
         final long most = buf.readLong();
@@ -93,7 +96,7 @@ public class MessageFoo implements IMessage {
 最后，回到刚才的`MySimpleNetworkHandler`，给它加个构造器：
 
 ```java
-private MySimpleNetworkHandler {
+private MySimpleNetworkHandler() {
     // 注册该 Message 及处理它的 Handler
     // 第三个参数是识别码 (discriminator)
     // 第四个参数是收包端，是逻辑端。


### PR DESCRIPTION
## Synopsis / 简介

清理第七章中对 `SimpleNetworkWrapper` 用法的说明。

## Description / 详细说明

 1. 不存在 `public UUID(String uuid)` 这样一个构造器。该 PR 修正为标准的接受两个 `long` 的构造器 `public UUID(long uuidMost, long uuidLeast)`，同时修改了序列化及反序列化流程以反映这个变化（顺带推广 best practice——尽可能同步最少的数据）。
 2. 修正不适当的语气。
 3. 特别注明 `IMessageHandler<REQ, REPLY>` 中的 `REPLY` 无法正常工作并给出相应的 Forge issue ticket。

## Justification / 理由

由 @TartaricAcid 发现的~~因不明原因忽略已久的~~问题。

## Remarks / 备注

N/A

<!-- 如果还有其他需要注意的事项，可放在这里。 -->
