### PR TITLE
fix: replace all "example_mod" to "my_mod"

### DIFF
--- a/chapter-02/index.md
+++ b/chapter-02/index.md
@@ -71,16 +71,19 @@ $ ./gradlew genIntellijRuns
 //
 // version 没有限制，若不填则使用 1.0，并产生警告。
 // 对于 version 来说，***强烈***推荐只用数字和点，比如只有 MAJOR.MINOR.PATCH 的 SemVer。
-@Mod(modid = "my_mod", name = "ExampleMod", version = "0.0.0")
-public enum ExampleMod {
+//
+// useMetadata = true 让 Forge 以 mcmod.info 里的信息为准。它的格式在“Mod 的元数据”一节
+// 会有详细说明。
+@Mod(modid = "my_mod", name = "My First Mod", version = "0.0.0", useMetadata = true)
+public enum MyMod {
     INSTANCE;
 
-    // Mod主类实例的“工厂”。
-    // 别的Mod开发教程肯定使用的是@Mod.Instance
+    // Mod 主类实例的“工厂”。
+    // 别的 Mod 开发教程肯定使用的是@Mod.Instance
     // 这里之所以这么写，是因为主类是 enum，换言之父类是 java.lang.Enum
-    // 因此，FML 直接 Class.newInstance() 的话会炸掉，java.lang.Enum 没有零参构造器
+    // 因此，FML 直接 Class.newInstance() 的话一定会报错，java.lang.Enum 没有零参构造器
     @Mod.InstanceFactory
-    public static ExampleMod getInstance() {
+    public static MyMod getInstance() {
         return INSTANCE;
     }
 
@@ -98,7 +101,7 @@ public enum ExampleMod {
     // 剩下两个事件只有在相当少见的情况下才会用到，大可暂时无视。
     @Mod.EventHandler
     public void preLoad(FMLPreInitializationEvent event) {
-        System.out.println("Hello, MinecraftForge");
+        System.out.println("Hello, Forge");
     }
 }
 ```

--- a/chapter-02/index.md
+++ b/chapter-02/index.md
@@ -71,7 +71,7 @@ $ ./gradlew genIntellijRuns
 //
 // version 没有限制，若不填则使用 1.0，并产生警告。
 // 对于 version 来说，***强烈***推荐只用数字和点，比如只有 MAJOR.MINOR.PATCH 的 SemVer。
-@Mod(modid = "example_mod", name = "ExampleMod", version = "0.0.0")
+@Mod(modid = "my_mod", name = "ExampleMod", version = "0.0.0")
 public enum ExampleMod {
     INSTANCE;
 

--- a/chapter-02/metadata.md
+++ b/chapter-02/metadata.md
@@ -6,7 +6,7 @@ Forge 允许你给你的 Mod 提供一个元数据描述文件，用于 Forge �
 ```json
 [
     {
-        "modid": "example_mod",
+        "modid": "my_mod",
         "name": "Example Mod",
         "description": "Just a demo mod",
         "version": "${version}",

--- a/chapter-02/metadata.md
+++ b/chapter-02/metadata.md
@@ -7,12 +7,10 @@ Forge 允许你给你的 Mod 提供一个元数据描述文件，用于 Forge �
 [
     {
         "modid": "my_mod",
-        "name": "Example Mod",
+        "name": "My First Mod",
         "description": "Just a demo mod",
         "version": "${version}",
-        "mcversion": "${mcversion}",
         "url": "http://example.net",
-        "updateUrl": "",
         "authorList": ["Some random guy"],
         "credits": "Forge guys",
         "logoFile": "logo.png",
@@ -25,8 +23,8 @@ Forge 允许你给你的 Mod 提供一个元数据描述文件，用于 Forge �
 ```
 
 `logoFile` 可以用来放你的 Mod 的 banner 或 logo。效果奇佳。注意不要太大，不然放不下。查找 `logoFile` 时的 `/` 是 jar 内部的根目录，对于源码来说，那就是 `src/main/resources/` 目录。和 `mcmod.info` 放一块就可以了。  
-此外，`updateUrl` 字段已 deprecated，没有任何效果。可以直接删除。  
-`useDependencyInformation` 的作用会在第 28 章讲到。
+
+`useDependencyInformation`、`requiredMods`、`dependencies` 的作用会在第 28 章讲到。
 
 # 数组？
 你应该注意到了这个 JSON 的最外层是个数组。这意味着，如果你的一个 jar 里有两个 `@Mod` 定义的 Mod，你可以利用这个数组把它们的元数据塞一起。

--- a/chapter-03/index.md
+++ b/chapter-03/index.md
@@ -74,7 +74,7 @@ MinecraftForge.EVENT_BUS.register(new EventListener());
 ```java
 // 这个注解的意思是“将这个类注册到事件总线中去，该事件监听器属于 my_mod 这个 Mod”
 // 它相当于 Forge 帮你执行了 MinecraftForge.EVENT_BUS.register(MyFirstEventListener.class)
-@Mod.EventBusSubscriber(modid = "example_mod")
+@Mod.EventBusSubscriber(modid = "my_mod")
 public final class MyFirstEventListener {
     @SubscribeEvent
     public static void onEventFired(ACertainEvent event) {

--- a/chapter-04/index.md
+++ b/chapter-04/index.md
@@ -63,14 +63,14 @@ public static Item yourItem = new Item()
  4. 在 `lang` 文件夹下新建 `en_us.lang`：
 
     ```
-    item.example_mod.example_item.name=Example Item
+    item.my_mod.example_item.name=Example Item
     ```
 
  5. 等等，如果没理解错，这是英文（美国）的 Locale 啊？  
     OK。然后还是 `lang` 文件夹，新建 `zh_cn.lang`：  
 
     ```
-    item.example_mod.example_item.name=示例物品
+    item.my_mod.example_item.name=示例物品
     ```
 
 ## 紫黑块？

--- a/chapter-07/forge-extension/fml-event-channel.md
+++ b/chapter-07/forge-extension/fml-event-channel.md
@@ -13,7 +13,7 @@ public enum MyNetworkManager {
     //当然也可以用别的，保证唯一即可。
     private final FMLEventChannel channel = NetworkRegistry.INSTANCE.newEventDrivenChannel(CHANNEL_NAME);
 
-    private static final String CHANNEL_NAME = "example_mod";
+    private static final String CHANNEL_NAME = "my_mod";
 
     private MyNetworkManager() {
         //注册listener

--- a/chapter-07/forge-extension/simple-network-wrapper.md
+++ b/chapter-07/forge-extension/simple-network-wrapper.md
@@ -12,7 +12,7 @@ public enum MySimpleNetworkHandler {
     INSTANCE;
 
     // 首先我们拿到一个 SimpleNetworkWrapper 的实例，然后对它进行封装
-    private final SimpleNetworkWrapper channel = NetworkRegistry.INSTANCE.newSimpleChannel("example_mod");
+    private final SimpleNetworkWrapper channel = NetworkRegistry.INSTANCE.newSimpleChannel("my_mod");
 
     // 向某个维度发包（服务器到客户端）
     public void sendMessageToDim(IMessage msg, int dim) {

--- a/chapter-11/baked/custom-mesh.md
+++ b/chapter-11/baked/custom-mesh.md
@@ -41,7 +41,7 @@ public class MyEpicTool extends Item {
     public MyEpicTool() {
         super();
         // 必要的初始化，请按需添加
-        this.addPropertyOverride(new ResourceLocation("example_mod", "test_damage"), new IItemPropertyGetter() {
+        this.addPropertyOverride(new ResourceLocation("my_mod", "test_damage"), new IItemPropertyGetter() {
             @Override
             @SideOnly(Side.CLIENT)
             public float apply(ItemStack stack, @Nullable World world, @Nullable EntityLivingBase entity) {
@@ -60,11 +60,11 @@ public class MyEpicTool extends Item {
     "...": "...",
     "overrides": [
         {
-            "predicate": { "example_mod:test_damage": 0.1 },
+            "predicate": { "my_mod:test_damage": 0.1 },
             "model": "..."
         },
         {
-            "predicate": { "example_mod:test_damage": 0.2 },
+            "predicate": { "my_mod:test_damage": 0.2 },
             "model": "..."
         }
     ]

--- a/chapter-11/baked/index.md
+++ b/chapter-11/baked/index.md
@@ -21,19 +21,19 @@ Minecraft 本身使用的 JSON 格式的模型定义在[中文 Minecraft Wiki][l
 {
     "parent": "item/generated",
     "textures": {
-        "layer0": "example_mod:item/example_item_texture"
+        "layer0": "my_mod:item/example_item_texture"
     }
 }
 ```
 
-可以说这是最简单的物品模型了——你只需要指定纹理（texture）的位置就可以了。`example_mod:example_item_texture` 意味着你的纹理应当位于 `assets/[modid]/textures/item/example_item_texture.png`，格式自然是 png，没得商量。  
+可以说这是最简单的物品模型了——你只需要指定纹理（texture）的位置就可以了。`my_mod:example_item_texture` 意味着你的纹理应当位于 `assets/[modid]/textures/item/example_item_texture.png`，格式自然是 png，没得商量。  
 完成这些后，订阅 `ModelRegistryEvent`：
 
 ```java
 @SubscribeEvent
 public static void onModelRegistration(ModelRegistryEvent event) {
     // 因为一些奇怪的原因，原版不会主动去搜索 Mod 的物品的模型的位置。我们需要手动指定一个。
-    ModelLoader.setCustomModelResourceLocation(myItem, 0, new ModelResourceLocation(new ResourceLocation("example_mod", "example_item_model"), "inventory"));
+    ModelLoader.setCustomModelResourceLocation(myItem, 0, new ModelResourceLocation(new ResourceLocation("my_mod", "example_item_model"), "inventory"));
 }
 ```
 
@@ -48,24 +48,24 @@ public static void onModelRegistration(ModelRegistryEvent event) {
 {
     "variants": {
         "normal": {
-            "model": "example_mod:example_block_model"
+            "model": "my_mod:example_block_model"
         }
     }
 }
 ```
 
-因为这个方块没什么特别的所以它只有一种状态：`normal`。对于那些有各种奇怪状态的方块，这里会稍微麻烦一些，但这是后话。和物品的模型类似，方块模型统一放在 `assets/[modid]/models/block` 目录下。也就是说，上面我们给出的 `example_mod:example_block_model` 代表 Minecraft 会去寻找 `assets/example_mod/models/block/example_block_model.json` 这个文件。切换到目标目录下新建这个文件：
+因为这个方块没什么特别的所以它只有一种状态：`normal`。对于那些有各种奇怪状态的方块，这里会稍微麻烦一些，但这是后话。和物品的模型类似，方块模型统一放在 `assets/[modid]/models/block` 目录下。也就是说，上面我们给出的 `my_mod:example_block_model` 代表 Minecraft 会去寻找 `assets/my_mod/models/block/example_block_model.json` 这个文件。切换到目标目录下新建这个文件：
 
 ```json
 {
     "parent": "block/cube",
     "textures": {
-        "up": "example_mod:blocks/example_block_texture_up",
-        "down": "example_mod:blocks/example_block_texture_down",
-        "west": "example_mod:blocks/example_block_texture_west",
-        "north": "example_mod:blocks/example_block_texture_north",
-        "east": "example_mod:blocks/example_block_texture_east",
-        "south": "example_mod:blocks/example_block_texture_south"
+        "up": "my_mod:blocks/example_block_texture_up",
+        "down": "my_mod:blocks/example_block_texture_down",
+        "west": "my_mod:blocks/example_block_texture_west",
+        "north": "my_mod:blocks/example_block_texture_north",
+        "east": "my_mod:blocks/example_block_texture_east",
+        "south": "my_mod:blocks/example_block_texture_south"
     }
 }
 ```
@@ -86,7 +86,7 @@ Item.getItemFromBlock(myBlock);
 
 ```json
 {
-    "parent": "example_mod:block/example_block_model"
+    "parent": "my_mod:block/example_block_model"
 }
 ```
 

--- a/chapter-11/entity-model/index.md
+++ b/chapter-11/entity-model/index.md
@@ -22,7 +22,7 @@ public class MyEntityRenderer extends Render<MyEntity> {
         return MY_ENTITY_TEXTURE;
     }
 
-    private static final ResourceLocation MY_ENTITY_TEXTURE = new ResourceLocation("example_mod", "textures/entity/first_entity.png");
+    private static final ResourceLocation MY_ENTITY_TEXTURE = new ResourceLocation("my_mod", "textures/entity/first_entity.png");
 }
 ```
 

--- a/chapter-11/forge-extension/forge-v1.md
+++ b/chapter-11/forge-extension/forge-v1.md
@@ -211,10 +211,10 @@ Forge BlockState V1 格式还允许你对模型（自然也包括子模型）做
 没错，四种可用的变换模板里的 `forge:default-item` 实际上是可以给物品用的。具体来说，是这样操作的：
 
 ```java
-ModelLoader.setCustomModelResourceLocation(myItem, 0, new ModelResourceLocation(new ResourceLocation("example_mod", "example_item_model"), "inventory"));
+ModelLoader.setCustomModelResourceLocation(myItem, 0, new ModelResourceLocation(new ResourceLocation("my_mod", "example_item_model"), "inventory"));
 ```
 
-实际上这个 `ModelResourceLocation` 也可以代表一个 BlockState JSON 的位置。比如上面这个例子中的 `ModelResourceLocation` 也可以指向 `assets/example_mod/blockstates/example_item_model.json` 中定义的 `variants.inventory`。事实上，Minecraft/Forge 也的确是会搜索这里的。  
+实际上这个 `ModelResourceLocation` 也可以代表一个 BlockState JSON 的位置。比如上面这个例子中的 `ModelResourceLocation` 也可以指向 `assets/my_mod/blockstates/example_item_model.json` 中定义的 `variants.inventory`。事实上，Minecraft/Forge 也的确是会搜索这里的。  
 但这里有一个坑：`variants` 同时也包含了所有方块状态中的属性列表，直接声明成这样会有歧义：
 
 ```json

--- a/chapter-12/potion.md
+++ b/chapter-12/potion.md
@@ -17,13 +17,13 @@ public class MyNewPotion extends Potion {
 ```java
 @SubscribeEvent
 public static void onPotionRegistration(RegistryEvent.Register<Potion> event) {
-    event.getRegistry().registerAll(new MyNewPotion().setRegistryName("example_mod", "my_potion"));
+    event.getRegistry().registerAll(new MyNewPotion().setRegistryName("my_mod", "my_potion"));
 }
 ```
 
 ## 给玩家加上
 
-只是测试有没有注册成功的话，可以使用命令 `/effect <玩家名> example_mod:my_potion 1 60` 来获得等级 1，持续 60 秒的你的效果。  
+只是测试有没有注册成功的话，可以使用命令 `/effect <玩家名> my_mod:my_potion 1 60` 来获得等级 1，持续 60 秒的你的效果。  
 如果需要加入到相关的逻辑的话，你需要 `EntityLivingBase` 下的 `addPotionEffect`（`func_70690_d`）：
 
 ```java

--- a/chapter-26/config-gui.md
+++ b/chapter-26/config-gui.md
@@ -36,7 +36,7 @@ public class MyModConfigGuiFactory implements IModGuiFactory {
 然后你需要 `MyModConfigGuiFactory` 的 caonical name，并把它填入 `@Mod` 中：
 
 ```java
-@Mod(modid = "example_mod", name = "ExampleMod", version = "0.0.0",
+@Mod(modid = "my_mod", name = "ExampleMod", version = "0.0.0",
     guiFactory = "my_mod.MyModConfigGuiFactory")
 ```
 

--- a/chapter-27/container/index.md
+++ b/chapter-27/container/index.md
@@ -18,7 +18,7 @@ FluidRegistry.addBucketForFluid(myFluid);
 但万能桶这个功能默认禁用。需要至少有一个 Mod 在 `FMLPreInitializationEvent` 之前显式要求启用此功能。通常可选择在Mod主类的构造器，或静态初始化块中，显式开启：
 
 ```java
-@Mod(modid = "example_mod", name = "Example Mod")
+@Mod(modid = "my_mod", name = "Example Mod")
 public class ExampleMod {
     public ExampleMod() {
         FluidRegistry.enableUniversalBucket();

--- a/chapter-27/index.md
+++ b/chapter-27/index.md
@@ -9,7 +9,7 @@
 ````java
 // 构造器中第一个参数是流体的唯一识别 ID，第二个参数是材质位置。
 // 同时有一个三参数构造器可用，此时第二个参数是静止时的材质，第三个是流动时的材质。
-public static final Fluid myFluid = new Fluid("example_fluid", new ResourceLocation("example_mod:example_fluid")).setGaseous(true).setDensity(Integer.MAX_VALUE);
+public static final Fluid myFluid = new Fluid("example_fluid", new ResourceLocation("my_mod:example_fluid")).setGaseous(true).setDensity(Integer.MAX_VALUE);
 
 // 此方法会返回一个 boolean。
 // 返回 true 代表注册成功。

--- a/chapter-27/render.md
+++ b/chapter-27/render.md
@@ -11,12 +11,12 @@ Forge 提供了一个已经实现好的流体模型，可以拿来就用。有�
 ModelLoader.setCustomStateMapper(myFluid.getBlock(), new StateMapperBase() {
     @Override
     protected ModelResourceLocation getModelResourceLocation(@Nonnull IBlockState state) {
-        return new ModelResourceLocation(new ResourceLocation("example_mod", "fluid"), "my_fluid");
+        return new ModelResourceLocation(new ResourceLocation("my_mod", "fluid"), "my_fluid");
     }
 });
 ```
 
-注意到 `setCustomStateMapper` 将目标方块指向了一个特殊的 `StateMapper`，它进而无条件将模型指向 `assets/example_mod/blockstates/fluid.json` 中定义的 `my_fluid` 这个 variant。下面是 `fluid.json` 中的内容：
+注意到 `setCustomStateMapper` 将目标方块指向了一个特殊的 `StateMapper`，它进而无条件将模型指向 `assets/my_mod/blockstates/fluid.json` 中定义的 `my_fluid` 这个 variant。下面是 `fluid.json` 中的内容：
 
 ```json
 {


### PR DESCRIPTION
## Synopsis / 简介

统一教程代码中的 MODID

## Description / 详细说明

将所有 `example_mod` 替换为 `my_mod`

## Justification / 理由

统一教程代码，方便模板仓库的建立。

## Remarks / 备注

<!-- 如果还有其他需要注意的事项，可放在这里。 -->
