### PR TITLE
feat(ch. 11): document isGlobalRenderer

### DIFF
--- a/chapter-11/tesr.md
+++ b/chapter-11/tesr.md
@@ -15,6 +15,13 @@ public class CrazyRenderer extends TileEntitySpecialRenderer<MyCrazyTileEntity> 
         // 3. destroyStage 大约是“方块被破坏的进度”的意思 // TODO 查清楚
         // 4. alpha // TODO 可能是“透明度”的意思，待查
     }
+    
+    @Override
+    public boolean isGlobalRenderer(MyCrazyTileEntity tile) { // 实际上是泛型参数
+        // 这个方法用于决定是否渲染类似信标光柱一样尺寸巨大的内容。
+        // 默认，若返回 false，那么这个 TESR 只会渲染半径 3 方块以内的内容
+        return true;
+    }
 }
 ```
 

--- a/chapter-11/tesr.md
+++ b/chapter-11/tesr.md
@@ -18,8 +18,8 @@ public class CrazyRenderer extends TileEntitySpecialRenderer<MyCrazyTileEntity> 
     
     @Override
     public boolean isGlobalRenderer(MyCrazyTileEntity tile) { // 实际上是泛型参数
-        // 这个方法用于决定是否渲染类似信标光柱一样尺寸巨大的内容。
-        // 默认，若返回 false，那么这个 TESR 只会渲染半径 3 方块以内的内容
+        // 这个方法用于决定是否渲染类似结构方块一样尺寸巨大，甚至跨区块的内容。
+        // 默认，若返回 false，那么这个 TESR 只会渲染玩家视锥（Frustum）覆盖范围内的内容。
         return true;
     }
 }

--- a/chapter-11/tesr.md
+++ b/chapter-11/tesr.md
@@ -19,7 +19,7 @@ public class CrazyRenderer extends TileEntitySpecialRenderer<MyCrazyTileEntity> 
     @Override
     public boolean isGlobalRenderer(MyCrazyTileEntity tile) { // 实际上是泛型参数
         // 这个方法用于决定是否渲染类似结构方块一样尺寸巨大，甚至跨区块的内容。
-        // 默认，若返回 false，那么这个 TESR 只会渲染玩家视锥（Frustum）覆盖范围内的内容。
+        // 默认为 false，若返回 false，那么这个 TESR 只有在处于玩家视锥（Frustum）覆盖区块内时才会渲染。
         return true;
     }
 }


### PR DESCRIPTION
## Synopsis / 简介

解释 `TileEntitySpecialRender.isGlobalRenderer`。

## Description / 详细说明

解释 `TileEntitySpecialRender.isGlobalRenderer` 与渲染范围之间的关系。

## Justification / 理由

需要渲染比较巨大的图案（比如信标光柱）的时候会用到这个。

## Remarks / 备注

Credit to @TartaricAcid
