### PR TITLE
fix(ch. 02): correct Gradle build success information

### DIFF
--- a/chapter-02/index.md
+++ b/chapter-02/index.md
@@ -24,7 +24,7 @@
     * Eclipse：在 `setupDecompWorkspace` 后接上 `eclipse`
     * IntelliJ IDEA：恭喜你，在这里你不需要加任何东西。
     * 其他 IDE：不好意思你需要找对应的 Gradle 插件来解决问题，请查阅相关资料获得更多帮助。在这里的话就什么也不用加好了。
-  6. 回车运行。若看到 `BUILD SUCCESSFUL` 字样则表示大功告成，否则重复步骤 3. 和 4.，直到看到那个 `BUILD SCCESSFUL` 为止。
+  6. 回车运行。若看到 `BUILD SUCCESSFUL` 字样则表示大功告成，否则重复步骤 3. 和 4.，直到看到那个 `BUILD SUCCESSFUL` 为止。
   7. 在你使用的 IDE 中以 Gradle 项目的形式导入工程目录。
 
 [ref-forge-home]: https://files.minecraftforge.net/

--- a/chapter-02/index.md
+++ b/chapter-02/index.md
@@ -24,7 +24,7 @@
     * Eclipse：在 `setupDecompWorkspace` 后接上 `eclipse`
     * IntelliJ IDEA：恭喜你，在这里你不需要加任何东西。
     * 其他 IDE：不好意思你需要找对应的 Gradle 插件来解决问题，请查阅相关资料获得更多帮助。在这里的话就什么也不用加好了。
-  6. 回车运行。若看到 `BUILD SUCCESS` 字样则表示大功告成，否则重复步骤 3. 和 4.，直到看到那个 `BUILD SCCESS` 为止。
+  6. 回车运行。若看到 `BUILD SUCCESSFUL` 字样则表示大功告成，否则重复步骤 3. 和 4.，直到看到那个 `BUILD SCCESSFUL` 为止。
   7. 在你使用的 IDE 中以 Gradle 项目的形式导入工程目录。
 
 [ref-forge-home]: https://files.minecraftforge.net/


### PR DESCRIPTION
## Synopsis / 简介

1.The word "SCCESSFUL" has a typo. The right word is "SUCCESSFUL".

2.Gradle outputs "BUILD SUCCESSFUL" instead of "BUILD SUCCESS" now. So
the "BUILD SUCCESS" message is wrong and the "BUILD SUCCESSFUL"
message is right.

## Description / 详细说明

When I was reading this tutorial, I saw the following sentence in [this file](chapter-02/index.md):

```
6.回车运行。若看到 BUILD SUCCESS 字样则表示大功告成，否则重复步骤 3. 和 4.，直到看到那个 BUILD SCCESS 为止。
```

And the word ```BUILD SCCESS``` had a typo. Not only so, I found that ```BUILD SUCCESS``` was not outputted by Gradle and ```BUILD SUCCESSFUL``` was the right output. So I opened this PR to fix these mistakes.

## Justification / 理由

1. ```BUILD SCCESS``` had a typo.

2. ```BUILD SUCCESS``` is not right.

## Remarks / 备注

The Gradle log output \(using IntelliJ IDEA\):

```
下午1:12:15: Executing task ':classes'...


> Configure project :
This mapping 'snapshot_20171003' was designed for MC 1.12! Use at your own peril.

> Task :deobfCompileDummyTask
> Task :deobfProvidedDummyTask
> Task :sourceApiJava UP-TO-DATE
> Task :compileApiJava NO-SOURCE
> Task :processApiResources NO-SOURCE
> Task :apiClasses UP-TO-DATE
> Task :sourceMainJava
> Task :compileJava
> Task :processResources UP-TO-DATE
> Task :classes

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
See https://docs.gradle.org/4.8.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 40s
6 actionable tasks: 4 executed, 2 up-to-date
下午1:12:56: Task execution finished ':classes'.

```
