### PR TITLE
Fix wrong method parameters in Dimension registry

### DIFF
--- a/chapter-19/dimension/index.md
+++ b/chapter-19/dimension/index.md
@@ -15,14 +15,15 @@ public static DimensionType myDim;
 public void preInit(FMLPreInitializationEvent event) {
     // 第一个参数代表此维度的内部名称。
     // 第二个参数是村庄等数据保存时会用到的“当前维度的专有后缀名”。
-    // 第三个参数是该维度使用的 WorldProvider 的类。要求这个类有零参构造器。
-    // 第四个参数代表“是否保持该维度的 spawn 区块一直加载”。
-    myDim = DimensionType.register("my_dimension", "_my_dim", MyWorldProvider.class, false);
-    // 在拿到自己的维度的 myDimType 后，需要再向 Forge 告知这一新的 DimensionType 的存在，
-    // 否则某些 Forge 加入的功能会无法在你的新维度中工作。
-    // 第一个参数便是维度 ID。维度 ID 是基于 Minecraft 1.12.2 的 Forge Mod 开发中
+    // 第三个参数是维度 ID。维度 ID 是基于 Minecraft 1.12.2 的 Forge Mod 开发中
     // 仍然需要手动指定数字 ID 的游戏内容，也因此几乎所有的 Modder 都会允许通过配置文件
     // 修改维度 ID。
+    // 第四个参数是该维度使用的 WorldProvider 的类。要求这个类有零参构造器。
+    // 第五个参数代表“是否保持该维度的 spawn 区块一直加载”。
+    myDim = DimensionType.register("my_dimension", "_my_dim", dimID, MyWorldProvider.class, false);
+    // 在拿到自己的维度的 myDimType 后，需要再向 Forge 告知这一新的 DimensionType 的存在，
+    // 否则某些 Forge 加入的功能会无法在你的新维度中工作。
+    // 第一个参数仍然是维度 ID，和上面保持一致即可。
     DimensionManager.registerDimension(dimID, myDim);
 }
 ```

--- a/chapter-19/dimension/index.md
+++ b/chapter-19/dimension/index.md
@@ -8,16 +8,23 @@
 import net.minecraft.world.DimensionType;
 import net.minecraftforge.common.DimensionManager;
 
-int dimID = 233;
-// 第一个参数代表此维度的数字 ID。
-// 第二个参数代表此维度的内部名称。
-// 第三个参数是村庄等数据保存时会用到的“当前维度的专有后缀名”。
-// 第四个参数是该维度使用的 WorldProvider 的类。要求这个类有零参构造器。
-// 第五个参数代表“是否保持该维度的 spawn 区块一直加载”。
-DimensionType myDimType = DimensionType.register(dimID, "my_dimension", "_my_dim", MyWorldProvider.class, false);
-// 在拿到自己的维度的 myDimType 后，需要再向 Forge 告知这一新的 DimensionType 的存在，
-// 否则某些 Forge 加入的功能会无法在你的新维度中工作。
-DimensionManager.registerDimension(dimID, myDimType);
+public static int dimID = 233;
+public static DimensionType myDim;
+
+@Mod.EventHandler
+public void preInit(FMLPreInitializationEvent event) {
+    // 第一个参数代表此维度的内部名称。
+    // 第二个参数是村庄等数据保存时会用到的“当前维度的专有后缀名”。
+    // 第三个参数是该维度使用的 WorldProvider 的类。要求这个类有零参构造器。
+    // 第四个参数代表“是否保持该维度的 spawn 区块一直加载”。
+    myDim = DimensionType.register("my_dimension", "_my_dim", MyWorldProvider.class, false);
+    // 在拿到自己的维度的 myDimType 后，需要再向 Forge 告知这一新的 DimensionType 的存在，
+    // 否则某些 Forge 加入的功能会无法在你的新维度中工作。
+    // 第一个参数便是维度 ID。维度 ID 是基于 Minecraft 1.12.2 的 Forge Mod 开发中
+    // 仍然需要手动指定数字 ID 的游戏内容，也因此几乎所有的 Modder 都会允许通过配置文件
+    // 修改维度 ID。
+    DimensionManager.registerDimension(dimID, myDim);
+}
 ```
 
 ## `WorldProvider`


### PR DESCRIPTION
## Synopsis / 简介

修复 19 章关于注册新维度的说明中错误的方法参数说明。

## Description / 详细说明

`DimensionType.register` 和维度 ID 无关，第一个参数也不是维度 ID，那是 `DimensionManager.registerDimension` 的锅。

## Justification / 理由

修正有问题的代码不需要理由。

## Remarks / 备注

N/A。
