### PR TITLE
fix(ch.26): display configElements directly in gui

### DIFF
--- a/chapter-26/config-gui.md
+++ b/chapter-26/config-gui.md
@@ -19,7 +19,7 @@ public class MyModConfigGuiFactory implements IModGuiFactory {
 
     @Override
     public GuiScreen createConfigGui(GuiScreen parent) {
-        return new GuiConfig(parent, Collections.singletonList(ConfigElement.from(MyModConfig.class)), "my_mod_id", false, false, "First line", "Second line");
+        return new GuiConfig(parent, ConfigElement.from(MyModConfig.class).getChildElements(), "my_mod_id", false, false, "First line", "Second line");
     }
 
     @Override


### PR DESCRIPTION
## Synopsis / 简介

<!-- 一句话解释这个 Pull Request 做的事情。 -->
使 GuiConfig 中的 IConfigElement 直接显示，而不是在一个层级之下。

## Description / 详细说明

<!-- 如有必要，在这里详细说明该 Pull Request 的变更。 -->

经过 `Collections.singletonList` 后，所有的 `IConfigElement` 都会被包在 `${Name}` 之下，如图所示：

![image](https://user-images.githubusercontent.com/8667822/71765666-8f768180-2f32-11ea-9f1f-42f2b0ce00f8.png)


## Justification / 理由

<!-- 说明该 Pull Request 的必要性。 -->
1. 直接显示更符合常识

## Remarks / 备注

<!-- 如果还有其他需要注意的事项，可放在这里。 -->
