### PR TITLE
[Meta] 关闭搜索插件以节省服务器流量

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,6 +3,7 @@
   "description": "Just Another FMLTutor For Future",
   "author": "https://github.com/TeamCovertDragon/Harbinger/graphs/contributors",
   "plugins": [
+    "-search",
     "katex",
     "splitter",
     "expandable-chapters",

--- a/chapter-14/index.md
+++ b/chapter-14/index.md
@@ -35,7 +35,7 @@ public class MyGui extends GuiContainer {
 public class MyContainer extends Container {
     // 此方法必须覆写，因为父类里这是个抽象方法。
     @Override
-    public boolean canPlayerInteractWith(EntityPlayer player) {
+    public boolean canInteractWith(EntityPlayer player) {
         return true;
         // 返回 false 的时候会给你关掉 GUI。
     }


### PR DESCRIPTION
## Synopsis / 简介

关闭搜索插件以节省服务器流量。

## Description / 详细说明

关闭 gitbook 自带的 search 插件。

## Justification / 理由

包含 Harbinger 和 fmltutor 在内，从 2月24日 至  3月9日 `search_index` 一共占用了 10.28 GiB 的服务器流量，超过 86% 。而且在大多数情况下读者并不会使用到此功能，固造成的影响在可接受范围内。

## Remarks / 备注

[统计数据](https://statistics.covertdragon.team/)
