### PR TITLE
Ch 02. 补充新版 IDEA 运行的资源丢失问题解决方案

### DIFF
--- a/chapter-02/index.md
+++ b/chapter-02/index.md
@@ -54,6 +54,16 @@ $ ./gradlew genIntellijRuns
 运行完之后你便能在 "Run…" 中找到名为“Minecraft Client”和“Minecraft Server”的配置了。  
 注意：这个 task 必须在项目已经导入进 IDEA 之后运行！<black>你以为刚才比 Eclipse 用户少打一行就算完了吗（笑）</black>
 
+如果你在用 IDEA 14 之后的版本~这之前的版本不会有人在用了吧~，你还需要在 `build.gradle` 添加以下内容来让 GradleStart 识别到 IDEA 新的资源文件存放目录。
+
+```groovy
+sourceSets {
+    main {
+        output.resourcesDir = output.classesDir
+    }
+}
+```
+
 ## 入口类
 
 和一般的教程不一样，这里的写法有些特殊：


### PR DESCRIPTION
## Synopsis / 简介

补充新版 IDEA 运行的资源丢失问题解决方案

## Description / 详细说明

在 Chapter 2 Index 的 IDEA 条目下添加让 GradleStart 识别到“新版” IDEA的资源文件位置的代码

## Justification / 理由

在一般情况下，GradleStart 会检测不到 IDEA 构建的资源文件，这会给 mod 开发带来很大的问题
这一段代码修复了这种情况，使 IDEA 的构建运行可以正常工作
