### PR TITLE
meta(github): deprecate our chat group in favor of discussion borad

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Harbinger 是一套全面的，基于 Forge 的，中文 Minecraft Mod 开发指
 
 * **如无特殊说明，本教程基于 Minecraft 1.12.2 Release 和 Forge 14.23.5.2836，MCP Mapping 版本使用 `stable_39`。本教程原则上不涉及任何旧版内容。**
   * 适用于新版本的 Minecraft+Forge 的指南已经提上日程，还请稍安勿躁。
-* 如有疑问，欢迎到[本项目的问题追踪器](https://github.com/TeamCovertDragon/Harbinger/issues)中提出，或加入这个 QQ 群咨询：128025486。
+* 如有疑问，欢迎到[本项目的问题追踪器](https://github.com/TeamCovertDragon/Harbinger/issues)中提出，亦可在[本项目的讨论版](https://github.com/TeamCovertDragon/Harbinger/discussions)中先进行讨论。
 * 本教程使用的目录分隔符（directory separator）统一为 `/`。
 * 这里不是 Java 教程。你必须掌握至少一门基于 JVM 的编程语言。对零基础新人来说，Java 就可以，先去花点时间把 Java 学了。Scala 用户用 Scala 当然也是十分欢迎的，只是笔者不会 Scala。
 


### PR DESCRIPTION
## Synopsis / 简介

弃用原先的讨论群，改用最近进入公测的 GitHub Discussion。

## Description / 详细说明

移除 README 中的讨论群群号，并添加本仓库所属的 Discussion 的链接。

## Justification / 理由

建群的一年多一来，讨论群的问题（很容易跑题、过往的历史难以查阅等等）也发现了不少，但使用其他的聊天软件也有这样或那样的问题，自建论坛维护起来也不容易，而 GitHub Discussion 则有可能是在这之间的一个平衡点。

## Remarks / 备注

> Good luck on this one.
